### PR TITLE
allow removal of configuration properties

### DIFF
--- a/boltkit/config.py
+++ b/boltkit/config.py
@@ -60,7 +60,13 @@ def update(path, properties):
                 value = properties[key]
                 if line.startswith(key + "=") or \
                         (line.startswith("#") and line[1:].lstrip().startswith(key + "=")):
-                    f_out.write("%s=%s\n" % (key, value))
+                    if value is None:
+                        if line.startswith("#"):
+                            f_out.write(line)
+                        else:
+                            f_out.write("#%s" % line)
+                    else:
+                        f_out.write("%s=%s\n" % (key, value))
 
                     del properties[key]
                     break
@@ -68,7 +74,8 @@ def update(path, properties):
                 f_out.write(line)
 
         for key, value in properties.items():
-            f_out.write("%s=%s\n" % (key, value))
+            if value is not None:
+                f_out.write("%s=%s\n" % (key, value))
 
 
 def extract_http_and_bolt_uris(path):

--- a/boltkit/config.py
+++ b/boltkit/config.py
@@ -60,13 +60,13 @@ def update(path, properties):
                 value = properties[key]
                 if line.startswith(key + "=") or \
                         (line.startswith("#") and line[1:].lstrip().startswith(key + "=")):
-                    if value is None:
+                    if value:
+                        f_out.write("%s=%s\n" % (key, value))
+                    else:
                         if line.startswith("#"):
                             f_out.write(line)
                         else:
                             f_out.write("#%s" % line)
-                    else:
-                        f_out.write("%s=%s\n" % (key, value))
 
                     del properties[key]
                     break
@@ -74,7 +74,7 @@ def update(path, properties):
                 f_out.write(line)
 
         for key, value in properties.items():
-            if value is not None:
+            if value:
                 f_out.write("%s=%s\n" % (key, value))
 
 


### PR DESCRIPTION
`neoctrl-configure` has no way to disable existing or newly added configuration properties.

The current behavior of 
```
neoctrl-configure prop1=
```
is that it will create an entry in neo4jj.conf
```
prop1=
```
At the moment it isn't well defined what this means and to my knowledge, there is no configuration requiring empty value.

This PR repurposes the notation 
```
neoctrl-configure prop1=
```
to modify the neo4j.conf in the following way
```
#prop1=old_value
```
and thus allowing to achieve any valid configuration with `neoctrl-configure`.